### PR TITLE
feat: add empty project creation

### DIFF
--- a/webapp/file_routes.py
+++ b/webapp/file_routes.py
@@ -2,6 +2,7 @@
 File management blueprint.
 
 POST   /api/files          — upload one or more files
+POST   /api/files/empty    — create a blank project (no files)
 GET    /api/files          — list owned + shared files
 PATCH  /api/files/<id>     — rename
 DELETE /api/files/<id>     — delete
@@ -103,6 +104,29 @@ def list_files():
         'owned':  [dict(r) for r in owned],
         'shared': [dict(r) for r in shared],
     })
+
+
+@file_bp.route('/api/files/empty', methods=['POST'])
+@requires_auth_api
+def create_empty_file():
+    user = get_current_user()
+    data = request.get_json() or {}
+    display_name = (data.get('displayName') or '').strip()
+    initial_prompt = (data.get('initialPrompt') or '').strip()
+    if not display_name:
+        return jsonify({'error': 'displayName required'}), 400
+
+    file_id = _gen_id()
+    with db() as conn:
+        conn.execute(
+            "INSERT INTO files"
+            " (id, user_id, original_name, display_name, file_type, file_path,"
+            "  original_mime_type, initial_prompt)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (file_id, user['id'], display_name, display_name, 'note', '', None,
+             initial_prompt or None),
+        )
+    return jsonify({'id': file_id, 'display_name': display_name, 'file_type': 'note'})
 
 
 @file_bp.route('/api/files', methods=['POST'])

--- a/webapp/static/js/dashboard.js
+++ b/webapp/static/js/dashboard.js
@@ -48,16 +48,20 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 });
 
 // Modal elements
-const uploadModal    = document.getElementById('upload-modal');
-const modalBackdrop  = document.getElementById('modal-backdrop');
-const modalName      = document.getElementById('modal-name');
-const modalPrompt    = document.getElementById('modal-prompt');
-const modalFileChips = document.getElementById('modal-file-chips');
-const modalMultiHint = document.getElementById('modal-multi-hint');
-const modalCancel    = document.getElementById('modal-cancel');
-const modalUpload    = document.getElementById('modal-upload');
+const uploadModal      = document.getElementById('upload-modal');
+const modalBackdrop    = document.getElementById('modal-backdrop');
+const modalTitle       = document.getElementById('modal-title');
+const modalSubtitle    = document.getElementById('modal-subtitle');
+const modalFilesSection = document.getElementById('modal-files-section');
+const modalName        = document.getElementById('modal-name');
+const modalPrompt      = document.getElementById('modal-prompt');
+const modalFileChips   = document.getElementById('modal-file-chips');
+const modalMultiHint   = document.getElementById('modal-multi-hint');
+const modalCancel      = document.getElementById('modal-cancel');
+const modalUpload      = document.getElementById('modal-upload');
 
 let pendingFiles = null;
+let isEmptyProject = false;
 
 // ---------------------------------------------------------------------------
 // Upload
@@ -81,34 +85,53 @@ uploadArea.addEventListener('drop', (e) => {
   if (e.dataTransfer.files.length) openModal(e.dataTransfer.files);
 });
 
+document.getElementById('new-empty-btn').addEventListener('click', (e) => {
+  e.stopPropagation();
+  openModal(null);
+});
+
 // ---------------------------------------------------------------------------
 // Modal
 // ---------------------------------------------------------------------------
 
 function openModal(files) {
-  pendingFiles = files;
+  isEmptyProject = !files;
+  pendingFiles = files || null;
 
-  // Pre-fill name from the first file (best guess for any count)
-  const firstName = files[0].name;
-  modalName.value = firstName.includes('.') ? firstName.slice(0, firstName.lastIndexOf('.')) : firstName;
+  if (isEmptyProject) {
+    modalTitle.textContent = 'New empty project';
+    modalSubtitle.textContent = 'Name it and optionally add instructions — you can add files later.';
+    modalFilesSection.classList.add('hidden');
+    modalUpload.textContent = 'Create';
+    modalName.value = '';
+    modalPrompt.value = '';
+    modalPrompt.placeholder = 'e.g. Track a guest list, plan a schedule, draft notes…';
+  } else {
+    modalTitle.textContent = 'New document';
+    modalSubtitle.textContent = 'Name it, add optional instructions, then upload.';
+    modalFilesSection.classList.remove('hidden');
+    modalUpload.textContent = 'Upload';
+    modalPrompt.placeholder = 'e.g. Create a weekly calendar view, highlight the totals…';
 
-  // Render file chips
-  modalFileChips.innerHTML = Array.from(files).map(f =>
-    `<span class="file-chip">${escHtml(f.name)}</span>`
-  ).join('');
+    const firstName = files[0].name;
+    modalName.value = firstName.includes('.') ? firstName.slice(0, firstName.lastIndexOf('.')) : firstName;
 
-  // Show multi-file hint when more than one file
-  modalMultiHint.classList.toggle('hidden', files.length <= 1);
+    modalFileChips.innerHTML = Array.from(files).map(f =>
+      `<span class="file-chip">${escHtml(f.name)}</span>`
+    ).join('');
 
-  modalPrompt.value = '';
+    modalMultiHint.classList.toggle('hidden', files.length <= 1);
+  }
+
   uploadModal.classList.remove('hidden');
   modalName.focus();
-  modalName.select();
+  if (!isEmptyProject) modalName.select();
 }
 
 function closeModal() {
   uploadModal.classList.add('hidden');
   pendingFiles = null;
+  isEmptyProject = false;
   fileInput.value = '';
 }
 
@@ -119,12 +142,19 @@ document.addEventListener('keydown', (e) => {
 });
 
 modalUpload.addEventListener('click', async () => {
-  if (!pendingFiles) return;
-  const files = Array.from(pendingFiles);  // copy before closeModal clears fileInput
   const displayName = modalName.value.trim();
   const initialPrompt = modalPrompt.value.trim();
-  closeModal();
-  await handleUpload(files, displayName, initialPrompt);
+
+  if (isEmptyProject) {
+    if (!displayName) { modalName.focus(); return; }
+    closeModal();
+    await handleCreateEmpty(displayName, initialPrompt);
+  } else {
+    if (!pendingFiles) return;
+    const files = Array.from(pendingFiles);  // copy before closeModal clears fileInput
+    closeModal();
+    await handleUpload(files, displayName, initialPrompt);
+  }
 });
 
 // Allow Enter in name field to submit
@@ -151,6 +181,21 @@ async function handleUpload(files, displayName = '', initialPrompt = '') {
   } finally {
     setUploading(false);
     fileInput.value = '';
+  }
+}
+
+async function handleCreateEmpty(displayName, initialPrompt) {
+  try {
+    const res = await fetch('/api/files/empty', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ displayName, initialPrompt }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    window.location.href = `/view/${data.id}`;
+  } catch (err) {
+    showToast(err.message, 'error');
   }
 }
 

--- a/webapp/templates/includes/dashboard_upload.html
+++ b/webapp/templates/includes/dashboard_upload.html
@@ -9,6 +9,13 @@
     </svg>
     <p class="text-gray-600 text-sm font-medium">Click to upload or drag and drop</p>
     <p class="text-gray-400 text-xs mt-1">PDF, image, Word, Excel, CSV, or text · multiple files OK</p>
+    <div class="mt-3 border-t border-dashed border-gray-200 pt-3">
+      <button id="new-empty-btn" type="button"
+              class="text-xs text-amber-600 hover:text-amber-700 font-medium transition"
+              onclick="event.stopPropagation()">
+        + Start with an empty project
+      </button>
+    </div>
   </div>
 
   <div id="upload-progress" class="hidden">
@@ -25,11 +32,11 @@
   <div class="absolute inset-0 bg-black bg-opacity-40" id="modal-backdrop"></div>
   <div class="relative bg-white rounded-xl shadow-xl w-full max-w-lg p-6">
 
-    <h2 class="text-lg font-semibold text-gray-800 mb-1">New document</h2>
-    <p class="text-xs text-gray-400 mb-5">Name it, add optional instructions, then upload.</p>
+    <h2 id="modal-title" class="text-lg font-semibold text-gray-800 mb-1">New document</h2>
+    <p id="modal-subtitle" class="text-xs text-gray-400 mb-5">Name it, add optional instructions, then upload.</p>
 
-    <!-- Files being uploaded -->
-    <div class="mb-4">
+    <!-- Files being uploaded (hidden in empty-project mode) -->
+    <div id="modal-files-section" class="mb-4">
       <p class="text-xs font-medium text-gray-500 mb-2 uppercase tracking-wide">Files</p>
       <div id="modal-file-chips" class="flex flex-wrap gap-2"></div>
       <p id="modal-multi-hint" class="hidden text-xs text-gray-400 mt-2">
@@ -41,7 +48,7 @@
     <div class="space-y-4">
       <div>
         <label class="block text-sm font-medium text-gray-700 mb-1">
-          Document name
+          Project name
           <span class="text-gray-400 font-normal ml-1">— the heading shown in your dashboard</span>
         </label>
         <input id="modal-name" type="text"
@@ -56,7 +63,7 @@
         <textarea id="modal-prompt" rows="3"
                   class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm resize-none
                          focus:ring-2 focus:ring-amber-400 focus:border-transparent outline-none"
-                  placeholder="e.g. Create a weekly calendar view, highlight the totals…"></textarea>
+                  placeholder="e.g. Track a guest list, plan a schedule, draft notes…"></textarea>
       </div>
     </div>
 


### PR DESCRIPTION
## What

Adds a way to create a blank project without uploading any files first.

## Changes

- **Backend**: `POST /api/files/empty` — creates a `file_type='note'` record with no source files. Takes `displayName` + optional `initialPrompt`.
- **Dashboard UI**: '+ Start with an empty project' button inside the upload area (stops click propagation so it doesn't trigger the file picker).
- **Upload modal**: now dual-mode — file upload vs. empty project. Title, subtitle, files section visibility, and button label all adapt based on mode.
- **On create**: redirects straight to `/view/<id>` where the user can chat to build content from scratch.

## Behavior

Empty projects have no source files. The view page's `_get_document_context()` already returns `''` when there are no source files, so the first chat message is the seed — e.g. 'Create a guest list for my birthday party' generates the whole thing from scratch.