### PR TITLE
feat: import project from URL (Google Docs, web pages)

### DIFF
--- a/webapp/file_routes.py
+++ b/webapp/file_routes.py
@@ -1,11 +1,12 @@
 """
 File management blueprint.
 
-POST   /api/files          — upload one or more files
-POST   /api/files/empty    — create a blank project (no files)
-GET    /api/files          — list owned + shared files
-PATCH  /api/files/<id>     — rename
-DELETE /api/files/<id>     — delete
+POST   /api/files            — upload one or more files
+POST   /api/files/empty      — create a blank project (no files)
+POST   /api/files/from-url   — import a URL (Google Doc, webpage, etc.)
+GET    /api/files            — list owned + shared files
+PATCH  /api/files/<id>       — rename
+DELETE /api/files/<id>       — delete
 """
 
 import os
@@ -103,6 +104,63 @@ def list_files():
     return jsonify({
         'owned':  [dict(r) for r in owned],
         'shared': [dict(r) for r in shared],
+    })
+
+
+@file_bp.route('/api/files/from-url', methods=['POST'])
+@requires_auth_api
+def import_from_url():
+    from url_fetcher import fetch_url
+    user = get_current_user()
+    data = request.get_json() or {}
+    url = (data.get('url') or '').strip()
+    display_name = (data.get('displayName') or '').strip()
+    initial_prompt = (data.get('initialPrompt') or '').strip()
+
+    if not url:
+        return jsonify({'error': 'url required'}), 400
+
+    try:
+        fetched = fetch_url(url)
+    except ValueError as e:
+        return jsonify({'error': str(e)}), 422
+    except Exception:
+        current_app.logger.error('URL fetch error', exc_info=True)
+        return jsonify({'error': 'Could not fetch the URL. Please check it and try again.'}), 500
+
+    text = fetched['text']
+    source_type = fetched['source_type']
+    final_name = display_name or fetched.get('title') or 'Imported document'
+
+    # Classify the extracted text using the same extractor path as text uploads
+    from extractor import extract_document
+    try:
+        result = extract_document(text.encode('utf-8'), 'text/plain', final_name + '.txt')
+    except Exception:
+        current_app.logger.warning('URL import: extractor failed, using raw text', exc_info=True)
+        result = {'text': text, 'file_type': source_type}
+
+    file_id = _gen_id()
+    text_file = _save_text(user['id'], result['text'])
+
+    with db() as conn:
+        conn.execute(
+            "INSERT INTO files"
+            " (id, user_id, original_name, display_name, file_type, file_path,"
+            "  original_mime_type, initial_prompt)"
+            " VALUES (?,?,?,?,?,?,?,?)",
+            (file_id, user['id'], url, final_name, result['file_type'], '',
+             'text/plain', initial_prompt or None),
+        )
+        conn.execute(
+            _SQL_INSERT_SOURCE_FILE_NEW,
+            (_gen_id(), file_id, final_name, text_file, 'text/plain', None, 'data'),
+        )
+
+    return jsonify({
+        'id':           file_id,
+        'display_name': final_name,
+        'file_type':    result['file_type'],
     })
 
 

--- a/webapp/requirements.txt
+++ b/webapp/requirements.txt
@@ -7,6 +7,6 @@ python-docx==1.1.2
 pypdf==5.4.0
 pandas==2.2.3
 openpyxl==3.1.5
-pandas==2.2.3
-openpyxl==3.1.5
+requests==2.32.3
+trafilatura==2.0.0
 git+https://github.com/aabtzu/fiat-lux-agents#egg=fiat-lux-agents

--- a/webapp/static/js/dashboard.js
+++ b/webapp/static/js/dashboard.js
@@ -62,6 +62,7 @@ const modalUpload      = document.getElementById('modal-upload');
 
 let pendingFiles = null;
 let isEmptyProject = false;
+let pendingUrl = null;
 
 // ---------------------------------------------------------------------------
 // Upload
@@ -88,6 +89,20 @@ uploadArea.addEventListener('drop', (e) => {
 document.getElementById('new-empty-btn').addEventListener('click', (e) => {
   e.stopPropagation();
   openModal(null);
+});
+
+const urlInput     = document.getElementById('url-input');
+const urlImportBtn = document.getElementById('url-import-btn');
+
+function triggerUrlImport() {
+  const url = urlInput.value.trim();
+  if (!url) return;
+  openModalForUrl(url);
+}
+
+urlImportBtn.addEventListener('click', (e) => { e.stopPropagation(); triggerUrlImport(); });
+urlInput.addEventListener('keydown', (e) => {
+  if (e.key === 'Enter') { e.preventDefault(); e.stopPropagation(); triggerUrlImport(); }
 });
 
 // ---------------------------------------------------------------------------
@@ -128,10 +143,29 @@ function openModal(files) {
   if (!isEmptyProject) modalName.select();
 }
 
+function openModalForUrl(url) {
+  isEmptyProject = false;
+  pendingFiles = null;
+  pendingUrl = url;
+
+  modalTitle.textContent = 'Import from URL';
+  const shortUrl = url.length > 60 ? url.slice(0, 57) + '…' : url;
+  modalSubtitle.textContent = shortUrl;
+  modalFilesSection.classList.add('hidden');
+  modalUpload.textContent = 'Import';
+  modalName.value = '';
+  modalPrompt.value = '';
+  modalPrompt.placeholder = 'e.g. Summarise the key points, extract all dates…';
+
+  uploadModal.classList.remove('hidden');
+  modalName.focus();
+}
+
 function closeModal() {
   uploadModal.classList.add('hidden');
   pendingFiles = null;
   isEmptyProject = false;
+  pendingUrl = null;
   fileInput.value = '';
 }
 
@@ -145,13 +179,17 @@ modalUpload.addEventListener('click', async () => {
   const displayName = modalName.value.trim();
   const initialPrompt = modalPrompt.value.trim();
 
-  if (isEmptyProject) {
+  if (pendingUrl) {
+    const url = pendingUrl;
+    closeModal();
+    await handleImportFromUrl(url, displayName, initialPrompt);
+  } else if (isEmptyProject) {
     if (!displayName) { modalName.focus(); return; }
     closeModal();
     await handleCreateEmpty(displayName, initialPrompt);
   } else {
     if (!pendingFiles) return;
-    const files = Array.from(pendingFiles);  // copy before closeModal clears fileInput
+    const files = Array.from(pendingFiles);
     closeModal();
     await handleUpload(files, displayName, initialPrompt);
   }
@@ -181,6 +219,26 @@ async function handleUpload(files, displayName = '', initialPrompt = '') {
   } finally {
     setUploading(false);
     fileInput.value = '';
+  }
+}
+
+async function handleImportFromUrl(url, displayName, initialPrompt) {
+  setUploading(true);
+  uploadStatus.textContent = 'Fetching URL…';
+  try {
+    const res = await fetch('/api/files/from-url', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ url, displayName, initialPrompt }),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+    urlInput.value = '';
+    window.location.href = `/view/${data.id}`;
+  } catch (err) {
+    showToast(err.message, 'error');
+  } finally {
+    setUploading(false);
   }
 }
 

--- a/webapp/templates/includes/dashboard_upload.html
+++ b/webapp/templates/includes/dashboard_upload.html
@@ -9,12 +9,24 @@
     </svg>
     <p class="text-gray-600 text-sm font-medium">Click to upload or drag and drop</p>
     <p class="text-gray-400 text-xs mt-1">PDF, image, Word, Excel, CSV, or text · multiple files OK</p>
-    <div class="mt-3 border-t border-dashed border-gray-200 pt-3">
+    <div class="mt-3 border-t border-dashed border-gray-200 pt-3 space-y-2">
       <button id="new-empty-btn" type="button"
               class="text-xs text-amber-600 hover:text-amber-700 font-medium transition"
               onclick="event.stopPropagation()">
         + Start with an empty project
       </button>
+      <div class="flex gap-2 items-center" onclick="event.stopPropagation()">
+        <input id="url-input" type="url"
+               placeholder="Or paste a URL — Google Doc, article, …"
+               class="flex-1 px-2.5 py-1.5 text-xs border border-gray-200 rounded-lg
+                      focus:ring-2 focus:ring-amber-300 focus:border-transparent outline-none
+                      text-gray-700 placeholder-gray-400">
+        <button id="url-import-btn" type="button"
+                class="px-3 py-1.5 bg-amber-100 text-amber-700 text-xs font-medium
+                       rounded-lg hover:bg-amber-200 transition whitespace-nowrap">
+          Import
+        </button>
+      </div>
     </div>
   </div>
 

--- a/webapp/url_fetcher.py
+++ b/webapp/url_fetcher.py
@@ -1,0 +1,209 @@
+"""
+URL fetching and text extraction for Fiat Lux.
+
+Handles:
+  Google Docs (public)  — export as plain text via /export?format=txt
+  Generic web pages     — trafilatura article extraction
+  Plain text URLs       — returned as-is
+
+Security: resolves hostname to IP before request to block SSRF against
+private/loopback networks.
+"""
+
+import ipaddress
+import logging
+import re
+import socket
+from urllib.parse import urlparse
+
+import requests
+import trafilatura
+
+logger = logging.getLogger(__name__)
+
+_FETCH_TIMEOUT = 15
+_MAX_BYTES = 5 * 1024 * 1024  # 5 MB
+
+_PRIVATE_NETWORKS = [
+    ipaddress.ip_network('10.0.0.0/8'),
+    ipaddress.ip_network('172.16.0.0/12'),
+    ipaddress.ip_network('192.168.0.0/16'),
+    ipaddress.ip_network('127.0.0.0/8'),
+    ipaddress.ip_network('169.254.0.0/16'),
+    ipaddress.ip_network('100.64.0.0/10'),
+    ipaddress.ip_network('::1/128'),
+    ipaddress.ip_network('fc00::/7'),
+    ipaddress.ip_network('fe80::/10'),
+]
+
+_GDOC_RE = re.compile(
+    r'docs\.google\.com/document/d/([A-Za-z0-9_-]+)'
+)
+_GSHEET_RE = re.compile(
+    r'docs\.google\.com/spreadsheets/d/([A-Za-z0-9_-]+)'
+)
+
+_HEADERS = {
+    'User-Agent': 'FiatLux/1.0 (document import; +https://fiatlux.ai)',
+    'Accept': 'text/html,text/plain,application/xhtml+xml;q=0.9,*/*;q=0.8',
+    'Accept-Language': 'en-US,en;q=0.5',
+}
+
+
+def _is_safe_url(url: str) -> tuple[bool, str]:
+    """Return (safe, reason). Resolves hostname to block private IPs."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ('http', 'https'):
+        return False, 'Only http:// and https:// URLs are supported.'
+    host = parsed.hostname
+    if not host:
+        return False, 'Could not parse hostname from URL.'
+    try:
+        addrs = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False, f'Could not resolve hostname: {host}'
+    for info in addrs:
+        try:
+            ip = ipaddress.ip_address(info[4][0])
+            if any(ip in net for net in _PRIVATE_NETWORKS):
+                return False, 'URL resolves to a private or internal address.'
+        except ValueError:
+            pass
+    return True, ''
+
+
+def _google_doc_export_url(url: str) -> str | None:
+    m = _GDOC_RE.search(url)
+    if m:
+        return f'https://docs.google.com/document/d/{m.group(1)}/export?format=txt'
+    return None
+
+
+def _google_sheet_export_url(url: str) -> str | None:
+    m = _GSHEET_RE.search(url)
+    if m:
+        return f'https://docs.google.com/spreadsheets/d/{m.group(1)}/export?format=csv'
+    return None
+
+
+def fetch_url(url: str) -> dict:
+    """Fetch a URL and return {'text': str, 'title': str, 'source_type': str}.
+
+    source_type ∈ {'gdoc', 'gsheet', 'article', 'text'}
+
+    Raises ValueError with a user-friendly message on failure.
+    """
+    url = url.strip()
+    safe, reason = _is_safe_url(url)
+    if not safe:
+        raise ValueError(reason)
+
+    # Google Sheets → export as CSV
+    gsheet_url = _google_sheet_export_url(url)
+    if gsheet_url:
+        return _fetch_google_sheet(gsheet_url, url)
+
+    # Google Docs → export as plain text
+    gdoc_url = _google_doc_export_url(url)
+    if gdoc_url:
+        return _fetch_google_doc(gdoc_url, url)
+
+    # Generic URL
+    return _fetch_webpage(url)
+
+
+def _fetch_google_doc(export_url: str, original_url: str) -> dict:
+    try:
+        resp = requests.get(export_url, timeout=_FETCH_TIMEOUT, headers=_HEADERS)
+    except requests.RequestException as e:
+        raise ValueError(f'Could not fetch Google Doc: {e}') from e
+
+    if resp.status_code == 403 or (
+        '<html' in resp.text[:500].lower() and 'sign in' in resp.text[:2000].lower()
+    ):
+        raise ValueError(
+            'This Google Doc is private. Open the doc, click Share → '
+            '"Anyone with the link" → Viewer, then try again.'
+        )
+    if not resp.ok:
+        raise ValueError(f'Google Docs returned HTTP {resp.status_code}.')
+
+    text = resp.text[:_MAX_BYTES]
+    title = _title_from_url(original_url) or 'Google Doc'
+    return {'text': text, 'title': title, 'source_type': 'gdoc'}
+
+
+def _fetch_google_sheet(export_url: str, original_url: str) -> dict:
+    try:
+        resp = requests.get(export_url, timeout=_FETCH_TIMEOUT, headers=_HEADERS)
+    except requests.RequestException as e:
+        raise ValueError(f'Could not fetch Google Sheet: {e}') from e
+
+    if resp.status_code == 403 or (
+        '<html' in resp.text[:500].lower() and 'sign in' in resp.text[:2000].lower()
+    ):
+        raise ValueError(
+            'This Google Sheet is private. Open the sheet, click Share → '
+            '"Anyone with the link" → Viewer, then try again.'
+        )
+    if not resp.ok:
+        raise ValueError(f'Google Sheets returned HTTP {resp.status_code}.')
+
+    text = resp.text[:_MAX_BYTES]
+    title = _title_from_url(original_url) or 'Google Sheet'
+    return {'text': text, 'title': title, 'source_type': 'gsheet'}
+
+
+def _fetch_webpage(url: str) -> dict:
+    try:
+        resp = requests.get(
+            url, timeout=_FETCH_TIMEOUT, headers=_HEADERS,
+            allow_redirects=True, stream=True,
+        )
+        content_type = resp.headers.get('content-type', '')
+        raw = b''
+        for chunk in resp.iter_content(chunk_size=65536):
+            raw += chunk
+            if len(raw) >= _MAX_BYTES:
+                break
+        resp.close()
+    except requests.RequestException as e:
+        raise ValueError(f'Could not fetch URL: {e}') from e
+
+    if not resp.ok:
+        raise ValueError(f'The URL returned HTTP {resp.status_code}.')
+
+    if 'text/plain' in content_type:
+        return {
+            'text': raw.decode('utf-8', errors='replace'),
+            'title': _title_from_url(url),
+            'source_type': 'text',
+        }
+
+    html = raw.decode('utf-8', errors='replace')
+    text = trafilatura.extract(
+        html,
+        include_comments=False,
+        include_tables=True,
+        no_fallback=False,
+    )
+    if not text or len(text.strip()) < 100:
+        raise ValueError(
+            'Could not extract readable text from this page. '
+            'It may require login, be mostly images, or block automated access.'
+        )
+
+    title = trafilatura.extract_metadata(html)
+    title = (title.title if title else None) or _title_from_url(url)
+    return {'text': text, 'title': title, 'source_type': 'article'}
+
+
+def _title_from_url(url: str) -> str:
+    """Fallback: derive a readable name from the URL path."""
+    path = urlparse(url).path.rstrip('/')
+    segment = path.split('/')[-1] if path else ''
+    # Strip common extensions
+    segment = re.sub(r'\.(html?|php|aspx?|jsp)$', '', segment, flags=re.IGNORECASE)
+    # Replace separators with spaces, title-case
+    name = re.sub(r'[-_]+', ' ', segment).strip().title()
+    return name or urlparse(url).netloc


### PR DESCRIPTION
## What

Adds a URL import option to the dashboard alongside file upload and empty project.

## Changes

### New: `url_fetcher.py`
- `fetch_url(url)` handles three cases:
  - **Google Docs**: rewrites to `/export?format=txt` — works for any 'Anyone with link' public doc, no OAuth needed
  - **Google Sheets**: rewrites to `/export?format=csv`  
  - **Generic URLs**: `trafilatura` article extraction (strips nav, ads, footers — much better than regex)
- SSRF protection: resolves hostname to IP first, rejects all private/loopback ranges (10.x, 192.168.x, 172.16.x, 127.x, 169.254.x, 100.64.x, IPv6 private)
- 5 MB cap, 15s timeout, descriptive error messages for private docs

### Backend
- `POST /api/files/from-url` — fetches URL, runs text through existing extractor for type classification, creates file + source_file record

### Frontend
- URL input bar in the upload area (paste + Enter or click Import)
- Upload modal adapts to URL mode: title 'Import from URL', truncated URL as subtitle, 'Import' button label, no file chips
- Shows 'Fetching URL…' in the upload progress state during fetch
- Clears URL input and redirects to `/view/<id>` on success

### New deps
- `requests==2.32.3`
- `trafilatura==2.0.0`

## Usage

- Public Google Doc: paste the share URL, hit Import
- Web article: paste any URL, hit Import — trafilatura strips the page down to body text
- Private Google Doc: get a clear error telling you to set sharing to 'Anyone with the link'